### PR TITLE
Add nonce validation to tag settings form.

### DIFF
--- a/davidson-domains-meta.php
+++ b/davidson-domains-meta.php
@@ -23,6 +23,8 @@ function ddm_options_page_html()
     <h2>Tags</h2>
     <form action="<?= plugins_url('updatesettings.php', __FILE__ ); ?>" method="post">
       <?php
+      // Add nonce to form.
+      wp_nonce_field('edit_tags', 'ddm_tag_nonce');
 
       $response = wp_remote_get( DDM_LIST );
 

--- a/updatesettings.php
+++ b/updatesettings.php
@@ -1,6 +1,20 @@
 <?php
 require( $_SERVER['DOCUMENT_ROOT'] .'/wp-load.php' );
 
+// Verify that only authorized users can access this.
+if (!current_user_can('manage_options')) {
+    status_header(403);
+    return;
+}
+
+// Verify that nonce is valid. Note that the second parameter
+// **MUST** be the same as when the nonce was defined in the
+// form.
+if (!wp_verify_nonce($_POST['ddm_tag_nonce'], 'edit_tags')) {
+    status_header(400, "Invalid nonce");
+    return;
+}
+
 $tags = $_POST['tags'];
 update_option('ddm_tags', $tags, yes);
 echo header('Location: ' . $_SERVER['HTTP_REFERER']);


### PR DESCRIPTION
Add a nonce field to the tags form and verify that it is correct after submission.

Fix #1.